### PR TITLE
Fix navigation buttons and update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,16 @@ Navigate to the project root directory (`financebook01`).
 
 1.  **Create a virtual environment (recommended):**
     ```bash
-    python -m venv venv
-    source .venv/bin/activate  # On Windows: venv\Scripts\activate
+    python -m venv .venv
+    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
     ```
 2.  **Install dependencies:**
     ```bash
     pip install -r requirements.txt
     ```
-    The `requirements.txt` file should include `fastapi`, `uvicorn`, `sqlmodel`, etc.
+The `requirements.txt` file should include `fastapi`, `uvicorn`, `sqlmodel`, etc.
+If you get a "uvicorn: command not found" error, ensure the virtual environment is activated
+and the dependencies were installed with `pip install -r requirements.txt`.
 
 **Running the backend server:**
 

--- a/frontend/src/pages/SummaryPage.tsx
+++ b/frontend/src/pages/SummaryPage.tsx
@@ -374,9 +374,20 @@ const SummaryPage: React.FC = () => {
 
   return (
     <>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '1rem',
+          gap: '0.5rem',
+        }}
+      >
         <h2>Payments</h2>
-        <button onClick={() => navigate('/categories')}>categories</button>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button onClick={() => navigate('/category-types')}>Category Types</button>
+          <button onClick={() => navigate('/categories')}>Categories</button>
+        </div>
       </div>
       <CategoryFilterWrapper>
         <h3>Filter by Categories</h3>


### PR DESCRIPTION
## Summary
- label start page link as "Category Types" and add a second button for categories
- clarify venv instructions in README and note how to fix missing `uvicorn`

## Testing
- `pytest`
- `npm run build` *(fails: vite not found)*
- `pip install -r requirements.txt` *(fails: no internet)*

------
https://chatgpt.com/codex/tasks/task_e_685482f3fad88321ad0c134c6c5fb683