### PR TITLE
Improve category editing with creation UI

### DIFF
--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -272,6 +272,7 @@ export function useCreateCategory() {
         queryClient.invalidateQueries({ queryKey: ['category-tree', data.parent_id] });
       }
       // Invalidate general category listings if any exist
+      queryClient.invalidateQueries({ queryKey: ['all-categories'] });
     },
   });
 }

--- a/frontend/src/pages/CategoryEditPage.tsx
+++ b/frontend/src/pages/CategoryEditPage.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo, useState, useRef } from 'react';
+import React, { useMemo, useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
-import { useAllCategories, useCategoryTypes, useUpdateCategory, uploadCategoryIcon } from '../api/hooks';
+import { useAllCategories, useCategoryTypes, useUpdateCategory, uploadCategoryIcon, useCreateCategory } from '../api/hooks';
 import { Category } from '../types';
 
 const PageWrapper = styled.div`
@@ -8,12 +8,6 @@ const PageWrapper = styled.div`
   color: #eaeaea;
 `;
 
-const EntryRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-`;
 
 const IconBox = styled.div`
   width: 40px;
@@ -34,9 +28,86 @@ const SaveButton = styled.button`
   margin-left: auto;
 `;
 
+const AddContainer = styled.div`
+  margin: 1rem 0;
+  padding: 1rem;
+  border: 1px solid #555;
+  border-radius: var(--radius-md);
+  background: #2a2a2a;
+`;
+
+const AddLabel = styled.div`
+  font-size: 0.8rem;
+  color: #bbb;
+  margin-bottom: 0.5rem;
+`;
+
+const AddRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const AddInput = styled.input`
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #555;
+  border-radius: var(--radius-md);
+  background: #333;
+  color: #eaeaea;
+`;
+
+const AddButton = styled.button`
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-positive);
+  color: white;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background: #059669;
+  }
+
+  &:disabled {
+    background: #666;
+    cursor: not-allowed;
+  }
+`;
+
+const Cell = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+`;
+
+const Label = styled.label`
+  font-size: 0.75rem;
+  color: #bbb;
+`;
+
+const StyledSelect = styled.select`
+  padding: 0.5rem;
+  border: 1px solid #555;
+  border-radius: var(--radius-md);
+  background: #333;
+  color: #eaeaea;
+`;
+
+const EntryGrid = styled.div`
+  display: grid;
+  grid-template-columns: 150px 1fr 1fr 60px auto;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+`;
+
 export default function CategoryEditPage() {
   const { data: categories = [] } = useAllCategories();
   const { data: types = [] } = useCategoryTypes();
+  const createCategoryMutation = useCreateCategory();
+  const [newCatName, setNewCatName] = useState('');
 
   const standardTypeId = useMemo(() => types.find(t => t.name === 'standard')?.id, [types]);
 
@@ -76,12 +147,47 @@ export default function CategoryEditPage() {
   return (
     <PageWrapper>
       <h1>Categories</h1>
+      <AddContainer>
+        <AddLabel>Add new Category</AddLabel>
+        <AddRow>
+          <AddInput
+            type="text"
+            value={newCatName}
+            onChange={e => setNewCatName(e.target.value)}
+            placeholder="Category name"
+          />
+          <AddButton
+            onClick={async () => {
+              const name = newCatName.trim();
+              if (!name) return;
+              const typeId = standardTypeId || (types[0] && types[0].id);
+              if (!typeId) return;
+              await createCategoryMutation.mutateAsync({ name, type_id: typeId, parent_id: null });
+              setNewCatName('');
+            }}
+            disabled={!newCatName.trim() || createCategoryMutation.isPending}
+          >
+            Add
+          </AddButton>
+        </AddRow>
+      </AddContainer>
       {sorted.map(cat => {
         const [parentId, setParentId] = useState<number | null>(cat.parent_id ?? null);
         const [typeId, setTypeId] = useState<number>(cat.type_id);
         const [icon, setIcon] = useState<File | null>(null);
+        const [preview, setPreview] = useState<string | null>(null);
         const fileRef = useRef<HTMLInputElement>(null);
         const updateMutation = useUpdateCategory(cat.id);
+
+        useEffect(() => {
+          if (!icon) {
+            setPreview(null);
+            return;
+          }
+          const url = URL.createObjectURL(icon);
+          setPreview(url);
+          return () => URL.revokeObjectURL(url);
+        }, [icon]);
 
         const validParents = categories.filter(c =>
           c.type_id === typeId && c.id !== cat.id && !getDescendants(cat.id).includes(c.id)
@@ -95,33 +201,52 @@ export default function CategoryEditPage() {
           await updateMutation.mutateAsync({ parent_id: parentId, type_id: typeId, icon_file });
         };
 
-        return (
-          <EntryRow key={cat.id}>
-            <span>{cat.name}</span>
-            <select value={parentId ?? ''} onChange={e => setParentId(e.target.value === '' ? null : parseInt(e.target.value))}>
-              <option value="">No parent</option>
-              {validParents.map(p => (
-                <option key={p.id} value={p.id}>{p.name}</option>
-              ))}
-            </select>
-            {!(standardTypeId && sorted[0] && cat.type_id === standardTypeId && cat.id === sorted[0].id) && (
-              <select value={typeId} onChange={e => setTypeId(parseInt(e.target.value))}>
-                {types.map(t => (
-                  <option key={t.id} value={t.id}>{t.name}</option>
-                ))}
-              </select>
-            )}
-            <IconBox onClick={() => fileRef.current?.click()}>
-              {cat.icon_file ? (
-                <img src={`/api/download_static/${cat.icon_file}`} alt="icon" />
+          return (
+            <EntryGrid key={cat.id}>
+              <span>{cat.name}</span>
+              <Cell>
+                <Label>Parent category</Label>
+                <StyledSelect
+                  value={parentId ?? ''}
+                  onChange={e => setParentId(e.target.value === '' ? null : parseInt(e.target.value))}
+                >
+                  <option value="">No parent</option>
+                  {validParents.map(p => (
+                    <option key={p.id} value={p.id}>{p.name}</option>
+                  ))}
+                </StyledSelect>
+              </Cell>
+              {!(standardTypeId && sorted[0] && cat.type_id === standardTypeId && cat.id === sorted[0].id) ? (
+                <Cell>
+                  <Label>Type</Label>
+                  <StyledSelect value={typeId} onChange={e => setTypeId(parseInt(e.target.value))}>
+                    {types.map(t => (
+                      <option key={t.id} value={t.id}>{t.name}</option>
+                    ))}
+                  </StyledSelect>
+                </Cell>
               ) : (
-                <span>add icon</span>
+                <div />
               )}
-              <input type="file" accept="image/png" style={{ display: 'none' }} ref={fileRef} onChange={e => setIcon(e.target.files?.[0] || null)} />
-            </IconBox>
-            <SaveButton onClick={handleSave}>Save</SaveButton>
-          </EntryRow>
-        );
+              <IconBox onClick={() => fileRef.current?.click()}>
+                {preview ? (
+                  <img src={preview} alt="icon preview" />
+                ) : cat.icon_file ? (
+                  <img src={`/api/download_static/${cat.icon_file}`} alt="icon" />
+                ) : (
+                  <span>add icon</span>
+                )}
+                <input
+                  type="file"
+                  accept="image/png"
+                  style={{ display: 'none' }}
+                  ref={fileRef}
+                  onChange={e => setIcon(e.target.files?.[0] || null)}
+                />
+              </IconBox>
+              <SaveButton onClick={handleSave}>Save</SaveButton>
+            </EntryGrid>
+          );
       })}
     </PageWrapper>
   );


### PR DESCRIPTION
## Summary
- support invalidating all categories when new ones are created
- add UI on `CategoryEditPage` for creating categories
- improve layout of category editing rows
- instantly show uploaded icons on `CategoryEditPage`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856bd894a4c83218192d3f09e41fde0