### PR TITLE
Add category descendants endpoint and default category

### DIFF
--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -252,6 +252,21 @@ export function useCategoryTree(categoryId: number | undefined) {
     enabled: categoryId !== undefined,
   });
 }
+/**
+ * Fetch all descendants of a category by its ID.
+ */
+export function useCategoryDescendants(categoryId: number | undefined) {
+  return useQuery<Category[], Error>({
+    queryKey: ["category-descendants", categoryId],
+    queryFn: async () => {
+      if (categoryId === undefined) throw new Error("Category ID is undefined");
+      const res = await api.get<Category[]>(`/categories/${categoryId}/descendants`);
+      return res.data;
+    },
+    enabled: categoryId !== undefined,
+  });
+}
+
 
 /**
  * Provides a mutation hook for creating a new category.

--- a/frontend/src/components/PaymentItemForm.tsx
+++ b/frontend/src/components/PaymentItemForm.tsx
@@ -525,7 +525,7 @@ export const PaymentItemForm: React.FC = () => {
               disabled={loadingCategories}
             >
               <option value="">-- Select Category (Optional) --</option>
-              {categories?.map((category) => (
+              {categories?.filter(cat => cat.name !== "UNCLASSIFIED").map((category) => (
                 <option key={category.id} value={category.id.toString()}>
                   {category.name}
                 </option>

--- a/frontend/src/pages/SummaryPage.tsx
+++ b/frontend/src/pages/SummaryPage.tsx
@@ -332,9 +332,8 @@ const SummaryPage: React.FC = () => {
     );
   }, [paymentDataForMemo]);
 
-  // Get selected categories for display
   const selectedCategories = useMemo(() => {
-    return allCategories.filter(cat => selectedCategoryIds.includes(cat.id));
+    return allCategories.filter(cat => cat.name !== "UNCLASSIFIED" && selectedCategoryIds.includes(cat.id));
   }, [allCategories, selectedCategoryIds]);
 
   /* ---------------------------------------------------------------------- */
@@ -400,7 +399,7 @@ const SummaryPage: React.FC = () => {
           >
             <option value="">Select a category...</option>
             {allCategories
-              .filter(cat => !selectedCategoryIds.includes(cat.id))
+              .filter(cat => cat.name !== "UNCLASSIFIED" && !selectedCategoryIds.includes(cat.id))
               .map(cat => (
                 <option key={cat.id} value={cat.id}>
                   {cat.name}


### PR DESCRIPTION
## Summary
- create UNCLASSIFIED default category on startup
- assign UNCLASSIFIED when no category is given on creation or update
- add API endpoint to list category descendants
- filter UNCLASSIFIED category out of selection dropdowns
- expose hook to fetch category descendants

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68574b1a86008321b45c92150ef6803a