### PR TITLE
Enable editing payments via summary

### DIFF
--- a/frontend/src/pages/SummaryPage.tsx
+++ b/frontend/src/pages/SummaryPage.tsx
@@ -590,6 +590,7 @@ interface PaymentItemLineProps {
 
 // This component displays a single payment item in our list.
 const PaymentItemLine: React.FC<PaymentItemLineProps> = ({ item, allCategories, standardTypeId }) => {
+  const navigate = useNavigate();
   // This gets the URL for the payment item's image.
   const imageUrl = item.attachment_url;
   // This fetches the recipient information for the payment item.
@@ -610,8 +611,12 @@ const PaymentItemLine: React.FC<PaymentItemLineProps> = ({ item, allCategories, 
     return null;
   }, [item.categories, standardTypeId, allCategories]);
 
+  const handleDoubleClick = () => {
+    navigate(`/payment/${item.id}/edit`);
+  };
+
   return (
-    <Entry>
+    <Entry onDoubleClick={handleDoubleClick}>
       <ImageHolder>
         {imageUrl ? (
           <img src={imageUrl} alt="Payment attachment" />


### PR DESCRIPTION
## Summary
- allow PaymentItemForm to be reused for editing payment entries
- handle asynchronous initialData updates and pass submission state
- show update button text when editing
- enable navigation to EditItemPage when double clicking a payment item

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687aaac2e7608321bb50d50b8b2acae6